### PR TITLE
fix(Table): Refactor default prop assignment to resolve Babel parsing…

### DIFF
--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -34,17 +34,19 @@ const Table = <T extends Record<string, any>>({
   columns,
   data,
   onRowClick,
-  rowsPerPage = 10
+  rowsPerPage // Default value removed from signature
 }: TableProps<T>) => {
+  const actualRowsPerPage = rowsPerPage ?? 10; // Default value assigned here
+
   const [currentPage, setCurrentPage] = useState(1);
 
-  const totalPages = Math.ceil(data.length / rowsPerPage);
+  const totalPages = Math.ceil(data.length / actualRowsPerPage); // Use actualRowsPerPage
 
   const currentTableData = useMemo(() => {
-    const firstPageIndex = (currentPage - 1) * rowsPerPage;
-    const lastPageIndex = firstPageIndex + rowsPerPage;
+    const firstPageIndex = (currentPage - 1) * actualRowsPerPage; // Use actualRowsPerPage
+    const lastPageIndex = firstPageIndex + actualRowsPerPage; // Use actualRowsPerPage
     return data.slice(firstPageIndex, lastPageIndex);
-  }, [currentPage, data, rowsPerPage]);
+  }, [currentPage, data, actualRowsPerPage]); // Dependency updated
 
   const goToNextPage = () => {
     setCurrentPage((page) => Math.min(page + 1, totalPages));
@@ -61,14 +63,14 @@ const Table = <T extends Record<string, any>>({
           <thead>
             <tr>
               {columns.map((col) => (
-                <th key={col.key}>{col.header}</th> {/* col.key is now always string */}
+                <th key={col.key}>{col.header}</th>
               ))}
             </tr>
           </thead>
           <tbody>
             {currentTableData.map((item, rowIndex) => (
               <tr
-                key={item.id || rowIndex} // Assuming items might have an 'id' property
+                key={item.id || rowIndex}
                 onClick={() => onRowClick && onRowClick(item)}
                 className={onRowClick ? styles.clickableRow : ''}
               >
@@ -76,7 +78,7 @@ const Table = <T extends Record<string, any>>({
                   <td key={`${col.key}-${item.id || rowIndex}`}>
                     {col.render
                       ? col.render(item)
-                      : String(getNestedValue(item, col.key) ?? '')} {/* Use getNestedValue */}
+                      : String(getNestedValue(item, col.key) ?? '')}
                   </td>
                 ))}
               </tr>
@@ -92,7 +94,7 @@ const Table = <T extends Record<string, any>>({
         </table>
       </div>
 
-      {data.length > rowsPerPage && (
+      {data.length > actualRowsPerPage && ( // Use actualRowsPerPage
         <div className={styles.paginationControls}>
           <Button onClick={goToPreviousPage} disabled={currentPage === 1} variant="secondary">
             Previous


### PR DESCRIPTION
… error

This commit addresses a Babel parsing error (`Unexpected token`) in the `Table.tsx` component. The error was likely caused by the interaction of generics, destructured props with default values, and type annotations in the component's function signature.

The fix involves:
- Removing the default value assignment for the `rowsPerPage` prop from the function signature's destructuring.
- Assigning the default value for `rowsPerPage` (10) inside the function body using the nullish coalescing operator (`??`).
- Updating all internal usages of `rowsPerPage` to use this new internal constant (`actualRowsPerPage`).

This change does not alter the external behavior or API of the `Table` component but makes the syntax more robust against potential parser issues.